### PR TITLE
Adding normalized queries metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,8 +179,6 @@ func convert(data []byte) []byte {
 		res, err := json.Marshal(tps)
 		check(err, "Couldn't marshal object", log.Fields{"object": j})
 		log.WithField("marshaled", string(res)).Debug()
-		check(err, "Couldn't marshal object", log.Fields{"object": j})
-		log.WithField("marshaled", string(res)).Debug()
 		res = append(res, []byte("\n")...)
 		converted = append(converted, res...)
 	}
@@ -197,8 +195,6 @@ func consumed(f FileDesc) {
 		"new": new,
 	})
 }
-
-
 
 // Appends the given byte array to target file, saving it.
 func appendLog(converted []byte) {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -199,96 +198,7 @@ func consumed(f FileDesc) {
 	})
 }
 
-// Struct representing pgBadger output
-// List of first level keys (note that not all is of interest):
-//
-//	"normalyzed_info",
-//	"user_info",
-//	"top_locked_info",
-//	"host_info",
-//	"autovacuum_info",
-//	"autoanalyze_info",
-//	"tempfile_info",
-//	"top_tempfile_info",
-//	"session_info",
-//	"log_files",
-//	"logs_type",
-//	"checkpoint_info",
-//	"connection_info",
-//	"overall_checkpoint",
-//	"error_info",
-//	"database_info",
-//	"overall_stat",
-//	"nlines",
-//	"lock_info",
-//	"per_minute_info",
-//	"application_info",
-//	"top_slowest"
-//
-// Currently only top_slowest is converted. TODO add other stats.
-type PgBadgerOutputData struct {
-	PgBadgerTopSlowest []TopSlowest `json:"top_slowest"`
-}
 
-// Milli type is required to make duration unmarshalling flexible.
-// We just need to save milliseconds granularity.
-type Milli time.Duration
-
-type Timestamp time.Time
-
-// TopSlowest holds the mapped data to be marshaled and sent to ES.
-type TopSlowest struct {
-	Action    string    `json:"action"`
-	Timestamp Timestamp `json:"@timestamp"`
-	Duration  Milli     `json:"duration"`
-	Query     string    `json:"query"`
-	Username  string    `json:"username"`
-	Database  string    `json:"database"`
-}
-
-// UnmarshalJSON overrides the default unmarshalling, enabling PG log parsing.
-func (o *TopSlowest) UnmarshalJSON(data []byte) error {
-	var v [9]string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-
-	o.Action = actionKeyOnES
-	duration, err := time.ParseDuration(v[0] + "ms")
-	if err != nil {
-		return err
-	}
-	timestamp, err := time.Parse(timeStampParseLayout, v[1])
-	if err != nil {
-		return err
-	}
-	o.Timestamp = Timestamp(timestamp)
-	o.Duration = Milli(duration)
-	o.Query = v[2]
-	o.Username = v[3]
-	o.Database = v[4]
-	return nil
-}
-
-// String overriding to print milliseconds, not nanoseconds.
-func (o Milli) String() string {
-	return fmt.Sprintf("%v", time.Duration(o).Nanoseconds()/1e6)
-}
-
-// MarshalJSON overriding to print milliseconds, not nanoseconds.
-func (o Milli) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%v", o)), nil
-}
-
-// String overriding to force accepted timestamp format
-func (t Timestamp) String() string {
-	return time.Now().Format(timeStampPrintLayout)
-}
-
-// MarshalJSON overriding to force accepted timestamp format
-func (t Timestamp) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%v"`, t)), nil
-}
 
 // Appends the given byte array to target file, saving it.
 func appendLog(converted []byte) {

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 //	"time"
 	"fmt"
 	"encoding/json"
+	"strings"
 )
 
 const JSON_DATA = `
@@ -15,13 +16,13 @@ const JSON_DATA = `
       "chronos": {
         "20151006": {
           "18": {
-            "count": 22,
+            "count": 7,
             "duration": 7369.941,
             "min": {"00":3,"01":3,"02":4,"05":1,"07":1,"09":3,"10":7},
             "min_duration": {"00": 233.06,"01": 215.289,"02": 253.358,"05": 58.471,"07": 131.922,"09": 278.288,"10": 896.483}
           },
           "19": {
-            "count": 6,
+            "count": 2,
             "duration": 7369.941,
             "min": {"00":3,"01":3},
             "min_duration": {"00": 233.06,"01": 215.289}
@@ -36,17 +37,33 @@ const JSON_DATA = `
   ]
 }`
 
-func TestConversionTopSlowest(t *testing.T) {
+func TestConversion(t *testing.T) {
 	res := convert([]byte(JSON_DATA))
 	fmt.Println(len(res))
+
+	sres := string(res)
+	if !strings.Contains(sres,nfoActionKeyOnES) {
+		t.Errorf("Should have generated %v json data", nfoActionKeyOnES)
+	}
+	if !strings.Contains(sres,tslActionKeyOnES) {
+		t.Errorf("Should have generated %v json data", tslActionKeyOnES)
+	}
+	fmt.Println(sres)
 }
 
-func TestUnmarshalMarshal(t *testing.T) {
+func TestUnmarshal(t *testing.T) {
 	o := PgBadgerOutputData{}
 	json.Unmarshal([]byte(JSON_DATA), &o)
-	fmt.Println(o)
-	if _, err := json.Marshal(o); err != nil {
-		panic(o)
+
+	if len(o.PgBadgerTopSlowest) != 2 {
+		t.Errorf("Should have unmarshalled 2 top slowest elements, instead got %v when unmarshalled `%v`",
+			len(o.PgBadgerTopSlowest),
+			o.PgBadgerTopSlowest)
+	}
+	if len(o.PgBadgerNormalyzedInfo.Entries) != 9 {
+		t.Errorf("Should have unmarshalled 9 normalized info elements, instead got %v when unmarshalled `%v`",
+			len(o.PgBadgerNormalyzedInfo.Entries),
+			o.PgBadgerNormalyzedInfo)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -4,14 +4,50 @@ import (
 	"testing"
 //	"time"
 	"fmt"
+	"encoding/json"
 )
 
-const JSON_DATA = `{"overall_checkpoint": {}, "top_slowest": [["151.536","2015-09-25 16:53:55","SELECT 1","user1","db1",null,null,null,null],["147.257","2015-09-25 16:53:16","SELECT 2","user2","db2",null,null,null,null]]}`
+const JSON_DATA = `
+{
+  "overall_checkpoint": {},
+  "normalyzed_info": {
+    "commit;": {
+      "chronos": {
+        "20151006": {
+          "18": {
+            "count": 22,
+            "duration": 7369.941,
+            "min": {"00":3,"01":3,"02":4,"05":1,"07":1,"09":3,"10":7},
+            "min_duration": {"00": 233.06,"01": 215.289,"02": 253.358,"05": 58.471,"07": 131.922,"09": 278.288,"10": 896.483}
+          },
+          "19": {
+            "count": 6,
+            "duration": 7369.941,
+            "min": {"00":3,"01":3},
+            "min_duration": {"00": 233.06,"01": 215.289}
+          }
+        }
+      }
+    }
+  },
+  "top_slowest": [
+    ["151.536","2015-09-25 16:53:55","SELECT 1","user1","db1",null,null,null,null],
+    ["147.257","2015-09-25 16:53:16","SELECT 2","user2","db2",null,null,null,null]
+  ]
+}`
 
-func TestConversion(t *testing.T) {
+func TestConversionTopSlowest(t *testing.T) {
 	res := convert([]byte(JSON_DATA))
-
 	fmt.Println(len(res))
+}
+
+func TestUnmarshalMarshal(t *testing.T) {
+	o := PgBadgerOutputData{}
+	json.Unmarshal([]byte(JSON_DATA), &o)
+	fmt.Println(o)
+	if _, err := json.Marshal(o); err != nil {
+		panic(o)
+	}
 }
 
 func BenchmarkConversion(b *testing.B) {
@@ -19,4 +55,3 @@ func BenchmarkConversion(b *testing.B) {
 		convert([]byte(JSON_DATA))
 	}
 }
-

--- a/types.go
+++ b/types.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Struct representing pgBadger output
+// List of first level keys (note that not all is of interest):
+//
+//	"normalyzed_info", DONE
+//	"user_info",
+//	"top_locked_info",
+//	"host_info",
+//	"autovacuum_info",
+//	"autoanalyze_info",
+//	"tempfile_info",
+//	"top_tempfile_info",
+//	"session_info",
+//	"log_files",
+//	"logs_type",
+//	"checkpoint_info",
+//	"connection_info",
+//	"overall_checkpoint",
+//	"error_info",
+//	"database_info",
+//	"overall_stat",
+//	"nlines",
+//	"lock_info",
+//	"per_minute_info",
+//	"application_info",
+//	"top_slowest" DONE
+//
+// Currently only top_slowest is converted. TODO add other stats.
+type PgBadgerOutputData struct {
+	PgBadgerTopSlowest []TopSlowest `json:"top_slowest"`
+	//	PgBadgerNormalyzedInfo []NormalyzedInfo `json:"normalyzed_info"`
+}
+
+// Milli type is required to make duration unmarshalling flexible.
+// We just need to save milliseconds granularity.
+type Milli time.Duration
+
+type Timestamp time.Time
+
+// TopSlowest holds the mapped data to be marshaled and sent to ES.
+type TopSlowest struct {
+	Action    string    `json:"action"`
+	Timestamp Timestamp `json:"@timestamp"`
+	Duration  Milli     `json:"duration"`
+	Query     string    `json:"query"`
+	Username  string    `json:"username"`
+	Database  string    `json:"database"`
+}
+
+// UnmarshalJSON overrides the default unmarshalling, enabling PG log parsing.
+func (o *TopSlowest) UnmarshalJSON(data []byte) error {
+	var v [9]string
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	o.Action = actionKeyOnES
+	duration, err := time.ParseDuration(v[0] + "ms")
+	if err != nil {
+		return err
+	}
+	timestamp, err := time.Parse(timeStampParseLayout, v[1])
+	if err != nil {
+		return err
+	}
+	o.Timestamp = Timestamp(timestamp)
+	o.Duration = Milli(duration)
+	o.Query = v[2]
+	o.Username = v[3]
+	o.Database = v[4]
+	return nil
+}
+
+// String overriding to print milliseconds, not nanoseconds.
+func (o Milli) String() string {
+	return fmt.Sprintf("%v", time.Duration(o).Nanoseconds()/1e6)
+}
+
+// MarshalJSON overriding to print milliseconds, not nanoseconds.
+func (o Milli) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%v", o)), nil
+}
+
+// String overriding to force accepted timestamp format
+func (t Timestamp) String() string {
+	return time.Now().Format(timeStampPrintLayout)
+}
+
+// MarshalJSON overriding to force accepted timestamp format
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%v"`, t)), nil
+}


### PR DESCRIPTION
In addition to `top slowest` queries, a `normalized queries` metrics is useful to detect bad performing queries or overall system database usage degrading.

This PR sets the `normalized queries` output data ready to ship to Elastic Search.